### PR TITLE
Extend api with methods supporting context

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ func main() {
 }
 ```
 
+## Policies
+
+| policy                      | resource                               |
+|-----------------------------|----------------------------------------|
+| s3:ListBucket               | arn:aws:s3:::YOUR_BUCKET               |
+| s3:GetObject                | arn:aws:s3:::YOUR_BUCKET/YOUR_PREFIX/* |
+| s3:PutObject                | arn:aws:s3:::YOUR_BUCKET/YOUR_PREFIX/* |
+| s3:DeleteObject             | arn:aws:s3:::YOUR_BUCKET/YOUR_PREFIX/* |
+| s3:ListMultipartUploadParts | arn:aws:s3:::YOUR_BUCKET/YOUR_PREFIX/* |
+| s3:AbortMultipartUpload     | arn:aws:s3:::YOUR_BUCKET/YOUR_PREFIX/* |
+
 ## License
 
 MIT License

--- a/interface.go
+++ b/interface.go
@@ -9,9 +9,11 @@ import (
 
 type s3ApiClient interface {
 	HeadObject(ctx context.Context, params *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error)
-	ListObjectsV2(context.Context, *s3.ListObjectsV2Input, ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
+	CopyObject(ctx context.Context, params *s3.CopyObjectInput, optFns ...func(*s3.Options)) (*s3.CopyObjectOutput, error)
 	PutObject(context.Context, *s3.PutObjectInput, ...func(*s3.Options)) (*s3.PutObjectOutput, error)
 	GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+	DeleteObject(ctx context.Context, params *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
+	ListObjectsV2(context.Context, *s3.ListObjectsV2Input, ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
 	UploadPart(context.Context, *s3.UploadPartInput, ...func(*s3.Options)) (*s3.UploadPartOutput, error)
 	CreateMultipartUpload(context.Context, *s3.CreateMultipartUploadInput, ...func(*s3.Options)) (*s3.CreateMultipartUploadOutput, error)
 	CompleteMultipartUpload(context.Context, *s3.CompleteMultipartUploadInput, ...func(*s3.Options)) (*s3.CompleteMultipartUploadOutput, error)

--- a/tests/directory_test.go
+++ b/tests/directory_test.go
@@ -58,8 +58,19 @@ func TestDirectoryReadEmpty(t *testing.T) {
 
 	entries, err := fs.ReadDir(fsClient, "some-directory")
 	require.NoError(t, err)
-	require.Len(t, entries, 1)
-	assert.Equal(t, ".keep", entries[0].Name())
+	require.Len(t, entries, 0)
+}
+
+func TestDirectoryReadEmptyCustomDirectoryFile(t *testing.T) {
+	createBucket(t, "test")
+
+	fsClient := s3fs.New(client, "test", s3fs.WithDirectoryFile(".dir"))
+	_, err := fsClient.CreateDir("some-directory")
+	require.NoError(t, err)
+
+	entries, err := fs.ReadDir(fsClient, "some-directory")
+	require.NoError(t, err)
+	require.Len(t, entries, 0)
 }
 
 func TestDirectoryReadReturnsAnError(t *testing.T) {
@@ -139,4 +150,24 @@ func TestDirectoryCreateIsFile(t *testing.T) {
 
 	_, err := fsClient.CreateDir("test.txt")
 	require.ErrorIs(t, err, s3fs.ErrKeyAlreadyExists)
+}
+
+func TestDirectoryRename(t *testing.T) {
+	createBucket(t, "test")
+
+	createObject(t, "test", "a/test.txt", strings.NewReader(""))
+	fsClient := s3fs.New(client, "test")
+
+	err := fsClient.Rename("a", "b")
+	require.ErrorIs(t, err, s3fs.ErrDirectory)
+}
+
+func TestDirectoryRemove(t *testing.T) {
+	createBucket(t, "test")
+
+	createObject(t, "test", "a/test.txt", strings.NewReader(""))
+	fsClient := s3fs.New(client, "test")
+
+	err := fsClient.Remove("a")
+	require.ErrorIs(t, err, s3fs.ErrDirectory)
 }


### PR DESCRIPTION
Most methods now support context cancellation helping usage if behind
for example an http server.

Add new methods:
* Rename
* Remove

Similar to os.Rename and os.Remove, but without directory support.